### PR TITLE
more word-terminating characters

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -129,8 +129,9 @@ export class AppComponent {
 
     stoppedTypingAWord() {
         // TODO this list should probably be moved somewhere, and adapted accordingly
-        const WORD_TERMINATING_CHARACTER_CODES = [33 /*!*/, 34 /*"*/, 38 /*&*/, 40 /*(*/, 41 /*)*/, 44 /*,*/, 46 /*.*/,
-            47 /*/*/, 59 /*;*/, 63 /*?*/, 92 /*\*/, 160 /* */, 171 /*«*/, 187/*»*/, 8220 /*“*/, 8221 /*”*/, 8230 /*…*/];
+        const WORD_TERMINATING_CHARACTER_CODES = [10 /*\n*/, 33 /*!*/, 34 /*"*/, 38 /*&*/, 40 /*(*/, 41 /*)*/, 44 /*,*/,
+            46 /*.*/, 47 /*/*/, 58 /*:*/, 59 /*;*/, 63 /*?*/, 92 /*\*/, 160 /* */, 171 /*«*/, 187/*»*/, 8220 /*“*/,
+            8221 /*”*/, 8230 /*…*/];
         const editor: HTMLElement = document.getElementById(this.EDITOR_KEY)!;
         const lastCharacterCode = editor.innerText.charCodeAt(editor.innerText.length - 1);
         return WORD_TERMINATING_CHARACTER_CODES.includes(lastCharacterCode);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -130,7 +130,7 @@ export class AppComponent {
     stoppedTypingAWord() {
         // TODO this list should probably be moved somewhere, and adapted accordingly
         const WORD_TERMINATING_CHARACTER_CODES = [33 /*!*/, 34 /*"*/, 38 /*&*/, 40 /*(*/, 41 /*)*/, 44 /*,*/, 46 /*.*/,
-            47 /*/*/, 63 /*?*/, 92 /*\*/, 160 /* */, 8220 /*“*/, 8221 /*”*/];
+            47 /*/*/, 59 /*;*/, 63 /*?*/, 92 /*\*/, 160 /* */, 171 /*«*/, 187/*»*/, 8220 /*“*/, 8221 /*”*/, 8230 /*…*/];
         const editor: HTMLElement = document.getElementById(this.EDITOR_KEY)!;
         const lastCharacterCode = editor.innerText.charCodeAt(editor.innerText.length - 1);
         return WORD_TERMINATING_CHARACTER_CODES.includes(lastCharacterCode);


### PR DESCRIPTION
This PR contains a few more added word-terminating characters which I've found while using **penda**. To provide some context, the `stoppedTypingAWord` method is used to dictate during writing if the POST call for fetching text markings should be made. There are a few improvements and bugs associated with this current state, for which I intend to create additional issues and PRs.