### PR TITLE
coherent wording in variable names

### DIFF
--- a/src/app/TextMarking.ts
+++ b/src/app/TextMarking.ts
@@ -3,5 +3,5 @@ export interface TextMarking {
     to: number;
     type: string;
     description: string;
-    corrections: Array<string>;
+    suggestions: Array<string>;
 }

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -92,7 +92,7 @@
         min-height: 18rem !important;
     }
 
-    #corrections {
+    #suggestions {
         gap: 0.4rem !important;
     }
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -58,11 +58,11 @@
                 <ul class="list-group list-group-flush">
                     <li class="list-group-item"><b>({{textMarking.description}})</b>&nbsp;fjala
                         <b>{{processedText?.text?.slice(textMarking.from, textMarking.to)}}</b>&nbsp;nuk ekziston<span
-                                *ngIf="textMarking.corrections.length > 0">, a doje të shkruaje
-                            <div id="corrections" style="display: flex; justify-content: center; gap: 1rem;">
-                                <button *ngFor="let correction of textMarking.corrections; index as j"
-                                        class="highlighted suggestion" (click)="chooseCorrection(i, j)"
-                                        style="cursor: pointer;"><b>{{correction}}</b></button>
+                                *ngIf="textMarking.suggestions.length > 0">, a doje të shkruaje
+                            <div id="suggestions" style="display: flex; justify-content: center; gap: 1rem;">
+                                <button *ngFor="let suggestion of textMarking.suggestions; index as j"
+                                        class="highlighted suggestion" (click)="chooseSuggestion(i, j)"
+                                        style="cursor: pointer;"><b>{{suggestion}}</b></button>
                             </div>
                         </span>
                     </li>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -163,7 +163,7 @@ export class AppComponent {
         }
     }
 
-    chooseCorrection(textMarkingIndex: number, correctionIndex: number) {
+    chooseSuggestion(textMarkingIndex: number, suggestionIndex: number) {
         if (document.getElementById(this.POPOVER_KEY) != null) {
             document.getElementById(this.POPOVER_KEY)!.remove();
         }
@@ -175,7 +175,7 @@ export class AppComponent {
         const leftWrittenText = writtenText?.slice(0, textMarking.from);
         const rightWrittenText = writtenText?.slice(textMarking.to, writtenText.length);
 
-        const modifiedWrittenText = leftWrittenText + textMarking.corrections[correctionIndex] + rightWrittenText;
+        const modifiedWrittenText = leftWrittenText + textMarking.suggestions[suggestionIndex] + rightWrittenText;
 
         editor.innerHTML = modifiedWrittenText;
 
@@ -245,8 +245,8 @@ export class AppComponent {
         }
 
         const maxSuggestions = 3;
-        const corrections = this.processedText?.textMarkings[textMarkingIndex].corrections!;
-        popover.innerHTML = corrections.map(corr => '<span class="popoverSuggestion">' + corr + '</span>')
+        const suggestions = this.processedText?.textMarkings[textMarkingIndex].suggestions!;
+        popover.innerHTML = suggestions.map(sugg => '<span class="popoverSuggestion">' + sugg + '</span>')
             .slice(0, maxSuggestions).join("&nbsp<span class='tinyVerticalLine'>|</span>&nbsp");
         // .join("&nbsp<span class='vr tinyVerticalLine'></span>&nbsp");
         // TODO try button
@@ -279,7 +279,7 @@ export class AppComponent {
         const popoverSuggestions = this.elementRef.nativeElement.querySelectorAll(".popoverSuggestion")
         if (popoverSuggestions) {
             popoverSuggestions.forEach((node: any, suggestionIndex: number) =>
-                node.addEventListener('click', this.chooseCorrection.bind(this, textMarkingIndex, suggestionIndex)));
+                node.addEventListener('click', this.chooseSuggestion.bind(this, textMarkingIndex, suggestionIndex)));
         }
     }
 }


### PR DESCRIPTION
In some places we find the words "correction" and "suggestion" used interchangeably, this PR replaces the former with the latter. One reason, excluding the obvious need for wording coherency, is that "suggestion" seems as a better option as the application typically makes suggestions and can virtually never be so certain (e.g. the text might be of artistic nature) so that it can say that the offered words definitely are corrections.

A PR reflecting these changes in [quill](https://github.com/OpenCovenant/quill) will be created shortly.