### PR TITLE
small bug in a css class

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -24,7 +24,7 @@
     background-color: #FFC8C8;
 }
 
-.styling {
+.stylistic {
     background-color: #A1B6DC;
 }
 


### PR DESCRIPTION
Came across some bug when working with stylistic text markings. Typo in a CSS class, as it should be the same as [this](https://github.com/OpenCovenant/quill/blob/main/utils/utils.py#L15).