### PR TITLE
enable dynamic marking templates

### DIFF
--- a/src/app/TextMarking.ts
+++ b/src/app/TextMarking.ts
@@ -2,6 +2,7 @@ export interface TextMarking {
     from: number;
     to: number;
     type: string;
+    subtype: string;
     description: string;
     suggestions: Array<string>;
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -56,13 +56,15 @@
                     </div>
                 </div>
                 <ul class="list-group list-group-flush">
-                    <li class="list-group-item"><b>({{textMarking.description}})</b>&nbsp;fjala
-                        <b>{{processedText?.text?.slice(textMarking.from, textMarking.to)}}</b>&nbsp;nuk ekziston<span
-                                *ngIf="textMarking.suggestions.length > 0">, a doje të shkruaje
+                    <li class="list-group-item">
+                        <b>{{textMarking.subtype}}</b> - <span>{{textMarking.description}}</span>
+                        <span *ngIf="textMarking.suggestions.length > 0">
                             <div id="suggestions" style="display: flex; justify-content: center; gap: 1rem;">
                                 <button *ngFor="let suggestion of textMarking.suggestions; index as j"
                                         class="highlighted suggestion" (click)="chooseSuggestion(i, j)"
-                                        style="cursor: pointer;"><b>{{suggestion}}</b></button>
+                                        style="cursor: pointer;">
+                                    <b>{{suggestion}}</b>
+                                </button>
                             </div>
                         </span>
                     </li>


### PR DESCRIPTION
Contains changes to drop the hard-coded text marking template and allow for a variety of such structures. A PR mirroring these changes in the BE will be shortly created.